### PR TITLE
docs: fix apikey create command example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Manage API keys for programmatic access:
 
 ```bash
 # Create a new API key
-anytype auth apikey create --name "my-app"
+anytype auth apikey create "my-app"
 
 # List all API keys
 anytype auth apikey list


### PR DESCRIPTION
## Description

Fixes incorrect example in README.md for the `apikey create` command.

## Changes

- Changed `anytype auth apikey create --name "my-app"` to `anytype auth apikey create "my-app"`
- The command expects the name as a positional argument, not a flag

## Testing

Verified by checking the command implementation in `cmd/auth/apikey/create/create.go` which shows:
- `Use: "create <name>"` - name is a positional argument
- `Args: cmdutil.ExactArgs(1, ...)` - requires exactly 1 argument

The README had an inconsistency - line 53 shows the correct usage, but line 159 showed incorrect usage with `--name` flag.