### PR TITLE
Add support for building with self-hosted sync nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,9 @@ This is the Anytype CLI, a Go-based command-line interface for interacting with 
 # Build the CLI (includes embedded server, downloads tantivy library automatically)
 make build
 
+# Build with custom self-hosted network configuration
+make build ANY_SYNC_NETWORK=/path/to/heart.yml
+
 # Install to ~/.local/bin (user installation)
 make install
 
@@ -39,6 +42,16 @@ make build-windows-amd64
 - **Tantivy Library**: Automatically downloaded for your platform during `make build`
 - **C Compiler**: Required for CGO and linking tantivy library (clang on macOS, gcc on Linux, mingw on Windows)
 - **Go 1.20+**: Required for building the project
+
+### Self-Hosted Network Configuration
+
+To build the CLI for use with self-hosted sync nodes:
+
+1. **Generate Network Configuration**: Use `any-sync-network` tool or your self-hosted setup to generate a `heart.yml` configuration file
+2. **Build with Custom Network**: Run `make build ANY_SYNC_NETWORK=/path/to/heart.yml`
+3. **Install and Use**: The resulting binary will connect to your self-hosted sync nodes instead of the default Anytype network
+
+The network configuration is compiled into the binary at build time and cannot be changed at runtime.
 
 ## Development Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,11 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 OUTPUT ?= dist/anytype
 
+# Self-hosted network configuration (optional)
+# Set this to the path of your heart.yml file to build with custom sync nodes
+# Example: make build ANY_SYNC_NETWORK=/path/to/heart.yml
+ANY_SYNC_NETWORK ?=
+
 TANTIVY_VERSION := v1.0.4
 TANTIVY_LIB_PATH ?= dist/tantivy
 CGO_LDFLAGS := -L$(TANTIVY_LIB_PATH)
@@ -27,7 +32,12 @@ GOLANGCI_LINT_VERSION := v2.7.2
 
 build: download-tantivy ## Build the cli binary
 	@echo "Building anytype-cli with embedded anytype-heart server..."
-	@CGO_ENABLED=1 CGO_LDFLAGS="$(CGO_LDFLAGS)" GOOS=$(GOOS) GOARCH=$(GOARCH) go build -tags "$(BUILD_TAGS)" -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)" -o $(OUTPUT)
+	@if [ -n "$(ANY_SYNC_NETWORK)" ]; then \
+		echo "Using custom network configuration: $(ANY_SYNC_NETWORK)"; \
+		CGO_ENABLED=1 CGO_LDFLAGS="$(CGO_LDFLAGS)" GOOS=$(GOOS) GOARCH=$(GOARCH) ANY_SYNC_NETWORK=$(ANY_SYNC_NETWORK) go build -tags "$(BUILD_TAGS)" -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)" -o $(OUTPUT); \
+	else \
+		CGO_ENABLED=1 CGO_LDFLAGS="$(CGO_LDFLAGS)" GOOS=$(GOOS) GOARCH=$(GOARCH) go build -tags "$(BUILD_TAGS)" -ldflags "$(LDFLAGS) $(EXTRA_LDFLAGS)" -o $(OUTPUT); \
+	fi
 	@echo "Built successfully: $(OUTPUT)"
 
 cross-compile: ## Build for all platforms

--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ You can change the API listen address using `--listen-address` (e.g., `--listen-
 
 **Security note**: Always keep your API keys safe. If ports are exposed externally, third parties with your API key could gain unauthorized access to the spaces your headless instance has access to.
 
+#### Self-Hosted Sync Nodes
+
+To use the CLI with self-hosted sync nodes instead of the default Anytype network, you need to build the CLI with a custom network configuration file (`heart.yml`):
+
+```bash
+# Build with your self-hosted network configuration
+make build ANY_SYNC_NETWORK=/path/to/heart.yml
+
+# Then install and use normally
+make install
+anytype serve
+```
+
+The `heart.yml` file contains your self-hosted network configuration including coordinator, tree, and file node addresses. This configuration is compiled into the binary at build time. See the [self-hosting documentation](https://tech.anytype.io/how-to/self-hosting) for details on setting up self-hosted sync nodes and generating the network configuration file.
+
 ### Authentication
 
 Manage your Anytype account and authentication:
@@ -217,6 +232,9 @@ cd anytype-cli
 
 # Build the CLI (automatically downloads tantivy library)
 make build
+
+# Build with custom self-hosted network configuration
+make build ANY_SYNC_NETWORK=/path/to/heart.yml
 
 # Install to ~/.local/bin
 make install


### PR DESCRIPTION
This commit adds the ability to build anytype-cli with custom self-hosted network configuration, allowing users to connect to their own sync infrastructure instead of the default Anytype network.

Changes:
- Add ANY_SYNC_NETWORK parameter to Makefile
- Pass network config path to anytype-heart during build
- Document self-hosted configuration in README.md
- Update CLAUDE.md with build instructions for custom networks

Usage:
  make build ANY_SYNC_NETWORK=/path/to/heart.yml

The heart.yml file contains coordinator, tree, and file node addresses for the self-hosted network. This configuration is compiled into the binary at build time.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [ ] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [ ] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
