### PR TITLE
 Docker image: Move binary to /usr/local/bin for PATH access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 FROM alpine:3.23
 
 WORKDIR /app
+# Add /app to PATH
+ENV PATH="/app:${PATH}"
 
 # Install ca-certificates for TLS and netcat for health checks
 RUN apk add --no-cache ca-certificates netcat-openbsd

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@
 FROM alpine:3.23
 
 WORKDIR /app
-# Add /app to PATH
-ENV PATH="/app:${PATH}"
 
 # Install ca-certificates for TLS and netcat for health checks
 RUN apk add --no-cache ca-certificates netcat-openbsd
@@ -12,8 +10,8 @@ RUN apk add --no-cache ca-certificates netcat-openbsd
 # Pre-compiled binary is provided in build context as anytype-linux-{arch}
 # TARGETARCH is set automatically by docker buildx (amd64 or arm64)
 ARG TARGETARCH
-COPY anytype-linux-${TARGETARCH} /app/anytype
-RUN chmod +x /app/anytype
+COPY anytype-linux-${TARGETARCH} /usr/local/bin/anytype
+RUN chmod +x /usr/local/bin/anytype
 
 # Note: Running as root to avoid volume permission issues in docker-compose
 
@@ -28,5 +26,5 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD nc -z 127.0.0.1 31010 || exit 1
 
 # Run the embedded server in foreground
-ENTRYPOINT ["/app/anytype"]
+ENTRYPOINT ["anytype"]
 CMD ["serve"]


### PR DESCRIPTION
This allows calling anytype CLI without needing to use the full path.

<!-- This template inspired by https://github.com/open-sauced/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1 -->

---

- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

This PR adds the feature to invoke the `anytype` command in the container image without needing to use the full path.

### What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
<!-- 
Please provide links to issues, community forum posts, or other sources
-->

### Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?


<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests for further details.
-->
