### PR TITLE
[self-hosted] Change order of step 2 and 3

### DIFF
--- a/SELF-HOSTED.md
+++ b/SELF-HOSTED.md
@@ -40,7 +40,13 @@ nodes:
       - file
 ```
 
-### 2. Create Account with Network Config
+### 2. Start Server
+
+```bash
+anytype serve
+```
+
+### 3. Create Account with Network Config
 
 Use the `--network-config` flag when creating your account:
 
@@ -49,14 +55,6 @@ anytype auth create my-bot --network-config ~/.config/anytype/network.yml
 ```
 
 Save the account key - it's your only authentication credential. The network config path is saved to `~/.anytype/config.json` for future operations.
-
-### 3. Start Server
-
-```bash
-anytype serve
-```
-
-The server will connect to your self-hosted network using the saved configuration.
 
 ## Joining Spaces
 


### PR DESCRIPTION
- [x] I understand that contributing to this repository will require me to agree with the [CLA](https://github.com/anyproto/.github/blob/main/docs/CLA.md)

<!-- The bot will prompt you to accept the CLA by replying with a pre-composed message in the comments. If you have already accepted the CLA, you won't need to do it again. -->

---

### Description

As far as I can tell, these steps need to be flipped: Start the service first, then create the user. If I try to create the user first, I always hit this error:

> ✗ Failed to create account: anytype is not running. Start it with: anytype serve


### What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI

### Related Tickets & Documents
N/A

### Mobile & Desktop Screenshots/Recordings
N/A

### Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 [tech-docs](https://github.com/anyproto/tech-docs)
- [x] 🙅 no documentation needed

### [optional] Are there any post-deployment tasks we need to perform?
No